### PR TITLE
Fix typos, added dependence on `future`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ rstmake.sh
 grip
 test_images/
 **/*/pyc
+env/*
+images_*

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can also download using pip:
 $ pip install ImageScraper
 ``` 
 ####**Dependencies**
-Note that ``ImageScraper`` depends on ``lxml`` and ``requests``. 
+Note that ``ImageScraper`` depends on ``lxml``, ``requests``, and ``future``. 
 If you run into problems in the compilation of ``lxml`` through ``pip``, install the ``libxml2-dev`` and ``libxslt-dev`` packages on your system.
 
 Usage
@@ -28,7 +28,7 @@ Usage
 ```sh
 $ image-scraper [OPTIONS] URL
 ```
-You can also use it in your python scripts.
+You can also use it in your Python scripts.
 ```py
 import image_scraper
 image_scraper.scrape_images(URL)
@@ -85,7 +85,7 @@ Issues
 
 Q.)All images were not downloaded?
 
-It could be that the content was injected into the page via javascript and this scraper doesn't run javascript. 
+It could be that the content was injected into the page via JavaScript; this scraper doesn't run JavaScript. 
  
 
 Contribute

--- a/image_scraper/utils.py
+++ b/image_scraper/utils.py
@@ -18,7 +18,7 @@ def process_links(links, formats=["jpg", "png", "gif", "svg", "jpeg"]):
 
 def get_arguments():
     parser = argparse.ArgumentParser(
-        description='Dowloads images form given URL')
+        description='Downloads images from given URL')
     parser.add_argument('url2scrape', nargs=1, help="URL to scrape")
     parser.add_argument('-m', '--max-images', type=int, default=None,
                         help="Limit on number of images\n")
@@ -32,7 +32,7 @@ def get_arguments():
                         help="Print the URLs of the images",
                         action="store_true")
     parser.add_argument('--formats', nargs="*", default=None,
-                        help="sepcify formats in a list without any seperator. This arguent must be after the url.")
+                        help="Specify formats in a list without any separator. This argument must be after the URL.")
     parser.add_argument('--scrape-reverse', default=False,
                         help="Scrape the images in reverse order",
                         action="store_true")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lxml==3.2.3
 requests==2.1.0
+future==0.14.3

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-
 try:
         from setuptools import setup
 except ImportError:
@@ -6,7 +5,7 @@ except ImportError:
 
 setup(name='ImageScraper',
     version='2.0.5',
-    install_requires=['lxml', 'requests'],
+    install_requires=['lxml', 'requests', 'future'],
     author='Anantha Natarajan S',
     author_email='sananthanatarajan12@gmail.com',
     packages=['image_scraper'],


### PR DESCRIPTION
The dependency on `future` wasn't in `setup.py`, so I got errors when I installed. I added this dependency to `setup.py` and `requirements.txt`, and also mentioned it in the README along with the dependence on `lxml` and `requests`.

I also fixed a few typos in the command line help and the README.