### PR TITLE
:bug: fixed bug in progressbar.py

### DIFF
--- a/image_scraper/progressbar.py
+++ b/image_scraper/progressbar.py
@@ -232,6 +232,8 @@ class ProgressBar(object):
 
     def update(self, value):
         "Updates the progress bar to a new value."
+        if value <= 0.1:
+            value = 0
         assert 0 <= value <= self.maxval
         self.currval = value
         if not self._need_update() or self.finished:


### PR DESCRIPTION
Fixes #43 
Division by a very small pbar.currval results in eta becoming more than 1e17. So time.gmtime(eta) cannot handle such a large value, resulting in
```sh
ValueError: (75, 'Value too large for defined data type')
```