### PR TITLE
:wrench:Fix CI UserWarning on python-eggs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
 # command to install package
 install:
+  - pip install setuptools --upgrade
   - python setup.py install
   - pip install coveralls
 # command to run tests


### PR DESCRIPTION
UserWarning in Travis

```sh
/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/pkg_resources/__init__.py:1222: UserWarning: /home/travis/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
```

This warning will not show on upgrading setuptools