### PR TITLE
:bug: KeyboardInterrupt exits cleanly, fixes #52

### DIFF
--- a/image_scraper/__init__.py
+++ b/image_scraper/__init__.py
@@ -1,1 +1,1 @@
-from .mains import console_main
+from .mains import main

--- a/image_scraper/mains.py
+++ b/image_scraper/mains.py
@@ -12,8 +12,19 @@ import threading
 import sys
 
 
+def main():
+    """ Called when the command is executed
+
+        Calls the function that starts the script
+        handles KeyboardInterrupt
+    """
+    try:
+        console_main()
+    except KeyboardInterrupt:
+        print ("Scraping stopped by user.")
+
 def console_main():
-    """ This function is called when the command is executed. """
+    """ This function handles all the console action. """
     setproctitle('image-scraper')
     scraper = ImageScraper()
     scraper.get_arguments()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='ImageScraper',
       author_email='sananthanatarajan12@gmail.com',
       packages=['image_scraper'],
       entry_points={
-          'console_scripts': ['image-scraper=image_scraper:console_main'],
+          'console_scripts': ['image-scraper=image_scraper:main'],
       },
       test_suite='tests',
       url='https://github.com/sananth12/ImageScraper/',


### PR DESCRIPTION
Changed the entry point to `image_scraper.main`. The `main()` basically serves as a wrapper where `console_main()` is called and **KeyboardInterrupt** is handled.